### PR TITLE
Merge AddZipkinTraceSupport into master

### DIFF
--- a/ObservatibilityFirstSteps/ObservatibilityFirstSteps.csproj
+++ b/ObservatibilityFirstSteps/ObservatibilityFirstSteps.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="OpenTelemetry" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.8.1" />
   </ItemGroup>
 
 </Project>

--- a/ObservatibilityFirstSteps/Program.cs
+++ b/ObservatibilityFirstSteps/Program.cs
@@ -16,6 +16,7 @@ using var traceProvider = Sdk.CreateTracerProviderBuilder()
 	})
 	.AddConsoleExporter()
 	.AddOtlpExporter()
+	.AddZipkinExporter() //use only one environment. we have two just for demo.
 	.Build();
 
 //global http object

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,3 +6,7 @@ services:
     - 4317:4317     #message over gRPC
     - 4318:4318     #message over HTTP
     - 16686:16686   #jaeger UI
+  observatibilityfirststeps-zipkin:
+    container_name: "zipkin-container"
+    ports:
+    - 9411:9411

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,8 @@ services:
     build:
       context: .
       dockerfile: ObservatibilityFirstSteps/Dockerfile
+  observatibilityfirststeps-zipkin:
+    image: openzipkin/zipkin:3
+    build:
+     context: .
+     dockerfile: ObservatibilityFirstSteps/Dockerfile-zipkin


### PR DESCRIPTION
Add Zipkin support for tracing data. Install Nuget package, add image name and a version of it to docker-compose.yaml, add AddZipkinExporter method to program build. Stop the images in docker, use "docker compose down", "docker compose up" and 
build docker. Produce trace data. Inspect the data from zipkin.